### PR TITLE
feat: safe defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
 
 A plugin for adding [CSRF](https://en.wikipedia.org/wiki/Cross-site_request_forgery) protection to Fastify.  
-If you want to learn more about CSRF, see [pillarjs/understanding-csrf](https://github.com/pillarjs/understanding-csrf).
+If you want to learn more about CSRF, see [pillarjs/understanding-csrf](https://github.com/pillarjs/understanding-csrf) and [Cross-Site Request Forgery Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html)
+
+> CSRF prevention must always be accompanied by other security measures. We recommend using [fastify-helmet](https://github.com/fastify/fastify-helmet)
 
 # Install 
 ```js 
@@ -154,6 +156,7 @@ fastify.route({
 ```
 
 ### Options
+
 | Options      | Description |
 | ----------- | ----------- |
 | `cookieKey` |  The name of the cookie where the CSRF secret will be stored, default `_csrf`.     |
@@ -164,4 +167,5 @@ fastify.route({
 
 
 ## License
+
 [MIT](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -161,9 +161,10 @@ fastify.route({
 | ----------- | ----------- |
 | `cookieKey` |  The name of the cookie where the CSRF secret will be stored, default `_csrf`.     |
 | `cookieOpts` |  The cookie serialization options. See [fastify-cookie](https://github.com/fastify/fastify-cookie).    |
-| `sessionKey` |  The key where to store the CSRF secret in the session     |
-| `getToken` |  A sync function to get the CSRF secret from the request     |
-| `sessionPlugin` |  The session plugin that you are using (if applicable)     |
+| `sessionKey` |  The key where to store the CSRF secret in the session.     |
+| `getToken` |  A sync function to get the CSRF secret from the request.     |
+| `sessionPlugin` |  The session plugin that you are using (if applicable).     |
+| `csrfOpts` |  The csrf options. See  [csrf](https://github.com/pillarjs/csrf).     |
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ You can configure the function to read the CSRF token via the `getToken` option,
 ```js
 function getToken (req) {
   return (req.body && req.body._csrf) ||
-    (req.query && req.query._csrf) ||
     req.headers['csrf-token'] ||
     req.headers['xsrf-token'] ||
     req.headers['x-csrf-token'] ||

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ function getToken (req) {
 
 If you use `fastify-csrf` with `fastify-cookie`, the CSRF secret will be added to the response cookies.
 By default, the cookie used will be named `_csrf`, but you can rename it via the `cookieKey` option.
+When `cookieOpts` are provided, they **override** the default options. Make sure you restore any of the default options which provide sensible and secure defaults.
 
 ```js
 fastify.register(require('fastify-cookie'))

--- a/index.js
+++ b/index.js
@@ -14,14 +14,13 @@ const defaultOptions = {
 }
 
 async function csrfPlugin (fastify, opts) {
-  const tokens = new CSRF()
-
   const {
     cookieKey,
     cookieOpts,
     sessionKey,
     getToken,
-    sessionPlugin
+    sessionPlugin,
+    csrfOpts
   } = Object.assign({}, defaultOptions, opts)
 
   assert(typeof cookieKey === 'string', 'cookieKey should be a string')
@@ -32,6 +31,8 @@ async function csrfPlugin (fastify, opts) {
     ['fastify-cookie', 'fastify-session', 'fastify-secure-session'].includes(sessionPlugin),
     "sessionPlugin should be one of the following: 'fastify-cookie', 'fastify-session', 'fastify-secure-session'"
   )
+
+  const tokens = new CSRF(csrfOpts)
 
   const isCookieSigned = cookieOpts && cookieOpts.signed
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const { Forbidden } = require('http-errors')
 
 const defaultOptions = {
   cookieKey: '_csrf',
-  cookieOpts: { path: '/', sameSite: true },
+  cookieOpts: { path: '/', sameSite: true, httpOnly: true },
   sessionKey: '_csrf',
   getToken: getTokenDefault,
   sessionPlugin: 'fastify-cookie'

--- a/index.js
+++ b/index.js
@@ -106,7 +106,6 @@ async function csrfPlugin (fastify, opts) {
 
 function getTokenDefault (req) {
   return (req.body && req.body._csrf) ||
-    (req.query && req.query._csrf) ||
     req.headers['csrf-token'] ||
     req.headers['xsrf-token'] ||
     req.headers['x-csrf-token'] ||

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "fastify-cookie": "^4.1.0",
     "fastify-secure-session": "^2.3.0",
     "fastify-session": "^5.2.0",
+    "proxyquire": "^2.1.3",
+    "sinon": "^9.2.1",
     "standard": "^16.0.3",
     "tap": "^14.10.8",
     "tsd": "^0.14.0"

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -21,7 +21,6 @@ test('Cookies', t => {
     fastify.decorate('testType', 'fastify-cookie')
     return fastify
   }
-  runTest(t, load, { property: '_csrf', place: 'query' })
   runTest(t, load, { property: '_csrf', place: 'body' }, 'preValidation')
   runTest(t, load, { property: 'csrf-token', place: 'headers' })
   runTest(t, load, { property: 'xsrf-token', place: 'headers' })
@@ -39,7 +38,6 @@ test('Cookies signed', t => {
     fastify.decorate('testType', 'fastify-cookie')
     return fastify
   }
-  runTest(t, load, { property: '_csrf', place: 'query' })
   runTest(t, load, { property: '_csrf', place: 'body' }, 'preValidation')
   runTest(t, load, { property: 'csrf-token', place: 'headers' })
   runTest(t, load, { property: 'xsrf-token', place: 'headers' })
@@ -61,7 +59,6 @@ test('Fastify Session', t => {
     fastify.decorate('testType', 'fastify-session')
     return fastify
   }
-  runTest(t, load, { property: '_csrf', place: 'query' }, 'preValidation')
   runTest(t, load, { property: '_csrf', place: 'body' }, 'preValidation')
   runTest(t, load, { property: 'csrf-token', place: 'headers' }, 'preValidation')
   runTest(t, load, { property: 'xsrf-token', place: 'headers' }, 'preValidation')
@@ -78,7 +75,6 @@ test('Fastify Secure Session', t => {
     fastify.decorate('testType', 'fastify-secure-session')
     return fastify
   }
-  runTest(t, load, { property: '_csrf', place: 'query' })
   runTest(t, load, { property: '_csrf', place: 'body' }, 'preValidation')
   runTest(t, load, { property: 'csrf-token', place: 'headers' })
   runTest(t, load, { property: 'xsrf-token', place: 'headers' })
@@ -201,16 +197,7 @@ function runTest (t, load, tkn, hook = 'onRequest') {
     }
     t.notStrictEqual(tokenFirst, token)
 
-    if (tkn.place === 'query') {
-      response = await fastify.inject({
-        method: 'POST',
-        path: `/?${tkn.property}=${token}`,
-        payload: { hello: 'world' },
-        cookies: {
-          [cookie.name]: cookie.value
-        }
-      })
-    } else if (tkn.place === 'body') {
+    if (tkn.place === 'body') {
       response = await fastify.inject({
         method: 'POST',
         path: '/',

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -27,6 +27,24 @@ test('Cookies', t => {
   runTest(t, load, { property: 'x-csrf-token', place: 'headers' })
   runTest(t, load, { property: 'x-xsrf-token', place: 'headers' })
   runCookieOpts(t, load)
+
+  t.test('Default cookie options', async t => {
+    const fastify = await load()
+
+    fastify.get('/', async (req, reply) => {
+      const token = await reply.generateCsrf()
+      return { token }
+    })
+
+    const response = await fastify.inject({
+      method: 'GET',
+      path: '/'
+    })
+
+    const cookie = response.cookies[0]
+    t.match(cookie, { path: '/', sameSite: 'Strict', httpOnly: true })
+  })
+
   t.end()
 })
 


### PR DESCRIPTION
This PR includes several changes to make the plugin more secure by default. Some of them are breaking:

- allow providing options to the csrf package in order to customize the length of the secret and the salt
- BREAKING: remove support for extracting the token from the query, because insecure (can still be customized by providing a custom `getToken` option)
- BREAKING: generated cookies are now `httpOnly` by default
- added disclaimer to doc suggesting to accompany this plugin with fastify-helmet

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [x] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
